### PR TITLE
Use plain div as a ListBoxButton

### DIFF
--- a/src/Listbox.js
+++ b/src/Listbox.js
@@ -53,11 +53,12 @@ export const ListboxButton = {
   },
   render(h) {
     return h(
-      'button',
+      'div',
       {
         attrs: {
           id: this.id,
-          type: 'button',
+          role: 'button',
+          tabindex: '0',
           'aria-haspopup': 'listbox',
           'aria-labelledby': `${this.context.labelId.value} ${this.id}`,
           ...(this.context.isOpen.value ? { 'aria-expanded': 'true' } : {}),
@@ -68,6 +69,13 @@ export const ListboxButton = {
           },
           blur: () => {
             this.isFocused = false
+          },
+          keydown: (e) => {
+            const triggersToggle = [' ', 'Spacebar', 'Enter']
+            if (triggersToggle.includes(e.key)) {
+              e.preventDefault()
+              this.$el.click()
+            }
           },
           click: this.context.toggle,
         },


### PR DESCRIPTION
As mentioned in #5 there is a bug in FireFox when selecting a list item with a spacebar it would automatically re-open the ListBoxList because FireFox and Safari both issue additioinal click event on space bar key down on a button element.

Additionally, clicking the ListBoxButton while having the ListBoxList open, would result into the same bug. In FireFox the button is [not focused by default when it's clicked ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus). Which makes the `relatedTarget` for `focusout` event to be `null` in this case.

This PR updates the HTML element for ListBoxButton to be plain `div` with `role="button"` and `tabindex="0"` which fixes both issues.